### PR TITLE
Atualizaçação Android Embedding v2

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="my_card"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
Ao rodar o projeto o Flutter apresentava um aviso de descontinuação do Android Embedding v1. Mais especificamente no arquivo `android/app/main/AndroidManifest.xml`

Seguindo o [guia do flutter de atualização de projetos](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects), modifiquei o arquivo a fim de não gerar mais esse erro.

Nota: O Flutter ainda indica que existem migrações a serem feitas quanto ao Splash Screen, mas esses avisos, diferente do original, não impedem a construção do aplicativo sem a flag de ignorar descontinuações.